### PR TITLE
Fix edge case on sync command.

### DIFF
--- a/SyncCommands.php
+++ b/SyncCommands.php
@@ -299,7 +299,7 @@ class SyncCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
     else {
       $this->write("Syncing configuration for {$site} as {$environment}.");
       $alias = $this->siteAliasManager()->get("@{$site}.local");
-      $process = Drush::drush($alias, 'kit:conf', ['import', $environment], ['yes' => TRUE]);
+      $process = Drush::drush($alias, 'kit:conf', ['import', $site, $environment], ['yes' => TRUE]);
       $success = ($this->io()->isVerbose()) ? $process->run($process->showRealtime()) : $process->run();
       if ($success === 0) {
         $this->write("Imported configuration for {$site} as {$environment}.", 'success', TRUE);


### PR DESCRIPTION
Fix an instance where fin:conf is expecting certain parameters.

Found this issue where the site didn't use "www" as the site default.